### PR TITLE
Comment  docker-automysqlbackup

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -1,2 +1,2 @@
 [mysqldump]
-column-statistics=0
+# column-statistics=0


### PR DESCRIPTION
Comment  docker-automysqlbackup  because in mysql 5.7 it generate an error :
```
mysqldump: [ERROR] unknown variable 'column-statistics=0'
```